### PR TITLE
[RMQ.Consumer] Client-agnostic consumer

### DIFF
--- a/src/RMQ.Client.Abstractions/Consuming/ConsumerContext.cs
+++ b/src/RMQ.Client.Abstractions/Consuming/ConsumerContext.cs
@@ -1,40 +1,10 @@
-﻿using RabbitMQ.Client.Events;
-
-namespace RMQ.Client.Abstractions.Consuming;
-
-public class ConsumerContext<TMessage> : ConsumerContext
-{
-    internal ConsumerContext(BasicDeliverEventArgs deliverEventArgs, IServiceProvider serviceProvider)
-        : base(deliverEventArgs, serviceProvider)
-    {
-    }
-
-    internal static ConsumerContext<TMessage> From(ConsumerContext context) =>
-        context switch
-        {
-            ConsumerContext<TMessage> genericContext => genericContext,
-            _ => new ConsumerContext<TMessage>(context.NativeDeliverEvent, context.ServiceProvider)
-            {
-                StoredValues = context.StoredValues
-            }
-        };
-
-    /// <summary>
-    /// Decoded incoming message
-    /// </summary>
-    public TMessage? Message { get; set; }
-}
+﻿namespace RMQ.Client.Abstractions.Consuming;
 
 /// <summary>
 /// Incoming message pipeline context
 /// </summary>
 public abstract class ConsumerContext
 {
-    /// <summary>
-    /// Native RabbitMQ library incoming message event
-    /// </summary>
-    public BasicDeliverEventArgs NativeDeliverEvent { get; }
-
     /// <summary>
     /// Service provider
     /// </summary>
@@ -46,10 +16,27 @@ public abstract class ConsumerContext
     public IDictionary<string, object> StoredValues { get; internal init; } = new Dictionary<string, object>();
 
     protected ConsumerContext(
-        BasicDeliverEventArgs deliverEventArgs,
         IServiceProvider serviceProvider)
     {
-        NativeDeliverEvent = deliverEventArgs;
         ServiceProvider = serviceProvider;
     }
+}
+
+public class ConsumerContext<TNativeProperties, TMessage> : ConsumerContext
+{
+    internal ConsumerContext(IServiceProvider serviceProvider, TNativeProperties nativeProperties)
+        : base(serviceProvider)
+    {
+        NativeProperties = nativeProperties;
+    }
+
+    /// <summary>
+    /// Native RabbitMQ library incoming message event
+    /// </summary>
+    public TNativeProperties NativeProperties { get; }
+
+    /// <summary>
+    /// Decoded incoming message
+    /// </summary>
+    public TMessage? Message { get; set; }
 }

--- a/src/RMQ.Client.Abstractions/Consuming/ConsumerDelegate.cs
+++ b/src/RMQ.Client.Abstractions/Consuming/ConsumerDelegate.cs
@@ -4,6 +4,6 @@ public delegate Task<ProcessResult> ConsumerDelegate(
     ConsumerContext context,
     CancellationToken cancellationToken);
 
-public delegate Task<ProcessResult> ConsumerDelegate<TMessage>(
-    ConsumerContext<TMessage> context,
+public delegate Task<ProcessResult> ConsumerDelegate<TNativeProperties, TMessage>(
+    ConsumerContext<TNativeProperties, TMessage> context,
     CancellationToken cancellationToken);

--- a/src/RMQ.Client.Abstractions/Consuming/IConsumerBuilder.cs
+++ b/src/RMQ.Client.Abstractions/Consuming/IConsumerBuilder.cs
@@ -6,11 +6,21 @@
 public interface IConsumerBuilder
 {
     /// <summary>
-    /// Add middleware to the pipeline
+    /// Add client-agnostic middleware to the pipeline
     /// </summary>
-    /// <param name="middleware"></param>
+    /// <param name="middleware">Middleware</param>
     /// <returns>Builder itself for changing</returns>
     IConsumerBuilder With(Func<ConsumerDelegate, ConsumerDelegate> middleware);
+
+    /// <summary>
+    /// Add client-specific middleware to the pipeline
+    /// </summary>
+    /// <param name="middleware"></param>
+    /// <typeparam name="TNativeProperties"></typeparam>
+    /// <typeparam name="TMessage"></typeparam>
+    /// <returns></returns>
+    IConsumerBuilder With<TNativeProperties, TMessage>(
+        Func<ConsumerDelegate<TNativeProperties, TMessage>, ConsumerDelegate<TNativeProperties, TMessage>> middleware);
 
     /// <summary>
     /// Add middleware to the pipeline
@@ -35,9 +45,4 @@ public interface IConsumerBuilder
     /// <returns></returns>
     IConsumer BuildRabbit<TProcessor, TMessage>(RabbitConsumerParameters parameters)
         where TProcessor : IProcessor<TMessage>;
-
-    /// <summary>
-    /// Service provider
-    /// </summary>
-    IServiceProvider ServiceProvider { get; }
 }

--- a/src/RMQ.Client.Abstractions/Consuming/IConsumerMiddleware.cs
+++ b/src/RMQ.Client.Abstractions/Consuming/IConsumerMiddleware.cs
@@ -1,20 +1,28 @@
 ﻿namespace RMQ.Client.Abstractions.Consuming;
 
+public interface IConsumerMiddleware
+{
+    Task<ProcessResult> InvokeAsync(
+        ConsumerContext context,
+        ConsumerDelegate next,
+        CancellationToken cancellationToken);
+}
+
 /// <summary>
 /// Consumer pipeline middleware
 /// </summary>
-public interface IConsumerMiddleware
+public interface IConsumerMiddleware<TNativeProperties>
 {
     /// <summary>
     /// Consume handling method
     /// </summary>
-    /// <param name="context">The <see cref="ConsumerContext{TMessage}"/> for the current consume</param>
+    /// <param name="context">The <see cref="ConsumerContext{TNativeProperties, TMessage}"/> for the current consume</param>
     /// <param name="next">The delegate representing the remaining middleware in the consume pipelines</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <typeparam name="TMessage">Message type</typeparam>
     /// <returns>A <see cref="Task"/> that represents the execution of this middleware</returns>
     Task<ProcessResult> InvokeAsync<TMessage>(
-        ConsumerContext<TMessage> context,
-        ConsumerDelegate<TMessage> next,
+        ConsumerContext<TNativeProperties, TMessage> context,
+        ConsumerDelegate<TNativeProperties, TMessage> next,
         CancellationToken cancellationToken);
 }

--- a/src/RMQ.Client.Abstractions/Consuming/RabbitConsumerMiddleware.cs
+++ b/src/RMQ.Client.Abstractions/Consuming/RabbitConsumerMiddleware.cs
@@ -1,0 +1,14 @@
+using RabbitMQ.Client.Events;
+
+namespace RMQ.Client.Abstractions.Consuming;
+
+/// <summary>
+/// Base Rabbit-specific consumer middleware
+/// </summary>
+public abstract class RabbitConsumerMiddleware : IConsumerMiddleware<BasicDeliverEventArgs>
+{
+    public abstract Task<ProcessResult> InvokeAsync<TMessage>(
+        ConsumerContext<BasicDeliverEventArgs, TMessage> context,
+        ConsumerDelegate<BasicDeliverEventArgs, TMessage> next,
+        CancellationToken cancellationToken);
+}

--- a/src/RMQ.Client.Abstractions/Exceptions/ConsumerBuilderMiddlewareConventionException.cs
+++ b/src/RMQ.Client.Abstractions/Exceptions/ConsumerBuilderMiddlewareConventionException.cs
@@ -1,0 +1,21 @@
+using RMQ.Client.Abstractions.Consuming;
+
+namespace RMQ.Client.Abstractions.Exceptions;
+
+public class ConsumerBuilderMiddlewareConventionException : InvalidOperationException
+{
+    private ConsumerBuilderMiddlewareConventionException(string message) : base(message)
+    {
+    }
+
+    internal static ConsumerBuilderMiddlewareConventionException NoInvokeAsyncMethod(Type type) =>
+        new($"Middleware {type.FullName} has to have a method {nameof(IConsumerMiddleware.InvokeAsync)}");
+
+    internal static ConsumerBuilderMiddlewareConventionException AmbiguousInvokeAsyncMethods(Type type) =>
+        new($"Middleware {type.FullName} has multiple {nameof(IConsumerMiddleware.InvokeAsync)} methods");
+
+    internal static ConsumerBuilderMiddlewareConventionException MismatchParameters(Type type) =>
+        new($"Middleware {type.FullName} method {nameof(IConsumerMiddleware.InvokeAsync)} has to have first parameter of type {nameof(ConsumerContext)} and last of type {nameof(CancellationToken)}");
+
+    internal static ConsumerBuilderMiddlewareConventionException NotSupported() => new("Not supported");
+}

--- a/src/RMQ.Client.Abstractions/Producing/IProducerBuilder.cs
+++ b/src/RMQ.Client.Abstractions/Producing/IProducerBuilder.cs
@@ -40,9 +40,4 @@ public interface IProducerBuilder
     /// <param name="parameters">RabbitMQ producer parameters</param>
     /// <returns></returns>
     IProducer BuildRabbit(RabbitProducerParameters parameters);
-
-    /// <summary>
-    /// Service provider
-    /// </summary>
-    IServiceProvider ServiceProvider { get; }
 }

--- a/src/RMQ.Client.Tests/RabbitConsumerShould.cs
+++ b/src/RMQ.Client.Tests/RabbitConsumerShould.cs
@@ -1,0 +1,221 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using RabbitMQ.Client.Events;
+using RMQ.Client.Abstractions;
+using RMQ.Client.Abstractions.Consuming;
+
+namespace RMQ.Client.Tests;
+
+public class RabbitConsumerShould : IClassFixture<RabbitFixture>
+{
+    private readonly RabbitFixture fixture;
+    private readonly Mock<RabbitProducerShould.ITestCaller> caller;
+
+    public RabbitConsumerShould(
+        RabbitFixture fixture)
+    {
+        this.fixture = fixture;
+        caller = new Mock<RabbitProducerShould.ITestCaller>();
+        caller.Setup(c => c.Call(It.IsAny<string>()));
+        fixture.ServiceCollection.AddSingleton(caller.Object);
+        fixture.ServiceCollection.AddScoped<Processor>();
+        fixture.ServiceCollection.AddScoped<ClientAgnosticInterfacedMiddleware>();
+        fixture.ServiceCollection.AddScoped<ClientSpecificInterfacedMiddleware>();
+    }
+
+    [Fact(Skip = "No integration tests yet")]
+    public async Task ConsumeMessages()
+    {
+        using var consumer = fixture.GetConsumerBuilder()
+            .With(next => (context, token) =>
+            {
+                var testCaller = context.ServiceProvider.GetRequiredService<RabbitProducerShould.ITestCaller>();
+                testCaller.Call("ClientAgnosticLambdaMiddleware");
+                return next.Invoke(context, token);
+            })
+            .With<BasicDeliverEventArgs, RabbitMessage>(next => (context, token) =>
+            {
+                var testCaller = context.ServiceProvider.GetRequiredService<RabbitProducerShould.ITestCaller>();
+                testCaller.Call("ClientSpecificLambdaMiddleware");
+                return next.Invoke(context, token);
+            })
+            .WithMiddleware<ClientAgnosticInterfacedMiddleware>()
+            .WithMiddleware<ClientSpecificInterfacedMiddleware>()
+            .WithMiddleware<ClientSpecificWrongInterfacedMiddleware>()
+            .WithMiddleware<ClientAgnosticConventionalMiddleware>()
+            .WithMiddleware<ClientSpecificConventionalMiddleware>()
+            .WithMiddleware<GenericClientSpecificConventionalMiddleware>()
+            .WithMiddleware(typeof(GenericClientSpecificConventionalMiddleware<,>))
+            .BuildRabbit<Processor, RabbitMessage>(
+                new RabbitConsumerParameters("test", "test-queue", ProcessingOrder.Sequential));
+        consumer.Subscribe();
+
+        using var producer = fixture.GetProducerBuilder()
+            .BuildRabbit(new RabbitProducerParameters("test-exchange"));
+        await producer.Send("test", new RabbitMessage("message"), CancellationToken.None);
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        caller.Verify(c => c.Call("ClientAgnosticLambdaMiddleware"), Times.Once);
+        caller.Verify(c => c.Call("ClientSpecificLambdaMiddleware"), Times.Once);
+        caller.Verify(c => c.Call("ClientAgnosticInterfacedMiddleware"), Times.Once);
+        caller.Verify(c => c.Call("ClientSpecificInterfacedMiddleware"), Times.Once);
+        caller.Verify(c => c.Call("ClientAgnosticConventionalMiddleware"), Times.Once);
+        caller.Verify(c => c.Call("ClientSpecificConventionalMiddleware"), Times.Once);
+        caller.Verify(c => c.Call("GenericClientSpecificConventionalMiddleware"), Times.Once);
+        caller.Verify(c => c.Call("GenericClientSpecificConventionalMiddleware with BasicDeliverEventArgs, RabbitMessage"), Times.Once);
+        caller.Verify(c => c.Call("message"), Times.Once);
+        caller.VerifyNoOtherCalls();
+    }
+    
+    private class ClientAgnosticInterfacedMiddleware : IConsumerMiddleware
+    {
+        private readonly RabbitProducerShould.ITestCaller testCaller;
+
+        public ClientAgnosticInterfacedMiddleware(
+            RabbitProducerShould.ITestCaller testCaller)
+        {
+            this.testCaller = testCaller;
+        }
+        
+        public Task<ProcessResult> InvokeAsync(
+            ConsumerContext context,
+            ConsumerDelegate next,
+            CancellationToken cancellationToken)
+        {
+            testCaller.Call(nameof(ClientAgnosticInterfacedMiddleware));
+            return next.Invoke(context, cancellationToken);
+        }
+    }
+    private class ClientSpecificInterfacedMiddleware : IConsumerMiddleware<BasicDeliverEventArgs>
+    {
+        private readonly RabbitProducerShould.ITestCaller testCaller;
+
+        public ClientSpecificInterfacedMiddleware(
+            RabbitProducerShould.ITestCaller testCaller)
+        {
+            this.testCaller = testCaller;
+        }
+        
+        public Task<ProcessResult> InvokeAsync<TMessage>(
+            ConsumerContext<BasicDeliverEventArgs, TMessage> context,
+            ConsumerDelegate<BasicDeliverEventArgs, TMessage> next,
+            CancellationToken cancellationToken)
+        {
+            testCaller.Call(nameof(ClientSpecificInterfacedMiddleware));
+            return next.Invoke(context, cancellationToken);
+        }
+    }
+    private class ClientAgnosticConventionalMiddleware
+    {
+        private readonly ConsumerDelegate next;
+
+        public ClientAgnosticConventionalMiddleware(ConsumerDelegate next)
+        {
+            this.next = next;
+        }
+
+        public Task<ProcessResult> InvokeAsync(
+            ConsumerContext context,
+            RabbitProducerShould.ITestCaller testCaller,
+            CancellationToken cancellationToken)
+        {
+            testCaller.Call(nameof(ClientAgnosticConventionalMiddleware));
+            return next.Invoke(context, cancellationToken);
+        }
+    }
+    private class ClientSpecificConventionalMiddleware
+    {
+        private readonly ConsumerDelegate<BasicDeliverEventArgs, RabbitMessage> next;
+
+        public ClientSpecificConventionalMiddleware(
+            ConsumerDelegate<BasicDeliverEventArgs, RabbitMessage> next)
+        {
+            this.next = next;
+        }
+
+        public Task<ProcessResult> InvokeAsync(
+            ConsumerContext<BasicDeliverEventArgs, RabbitMessage> context,
+            RabbitProducerShould.ITestCaller testCaller,
+            CancellationToken cancellationToken)
+        {
+            testCaller.Call(nameof(ClientSpecificConventionalMiddleware));
+            return next.Invoke(context, cancellationToken);
+        }
+    }
+    private class ClientSpecificWrongInterfacedMiddleware : IConsumerMiddleware<string>
+    {
+        private readonly RabbitProducerShould.ITestCaller testCaller;
+
+        public ClientSpecificWrongInterfacedMiddleware(
+            RabbitProducerShould.ITestCaller testCaller)
+        {
+            this.testCaller = testCaller;
+        }
+
+        public Task<ProcessResult> InvokeAsync<TMessage>(
+            ConsumerContext<string, TMessage> context,
+            ConsumerDelegate<string, TMessage> next,
+            CancellationToken cancellationToken)
+        {
+            testCaller.Call("Whatever");
+            return next.Invoke(context, cancellationToken);
+        }
+    }
+    private class GenericClientSpecificConventionalMiddleware
+    {
+        private readonly ConsumerDelegate next;
+
+        public GenericClientSpecificConventionalMiddleware(
+            ConsumerDelegate next)
+        {
+            this.next = next;
+        }
+
+        public Task<ProcessResult> InvokeAsync<TNativeProperties, TMessage>(
+            ConsumerContext<TNativeProperties, TMessage> context,
+            RabbitProducerShould.ITestCaller testCaller,
+            CancellationToken cancellationToken)
+        {
+            testCaller.Call(nameof(GenericClientSpecificConventionalMiddleware));
+            return next.Invoke(context, cancellationToken);
+        }
+    }
+    private class GenericClientSpecificConventionalMiddleware<TNativeProperties, TMessage>
+    {
+        private readonly ConsumerDelegate<TNativeProperties, TMessage> next;
+
+        public GenericClientSpecificConventionalMiddleware(
+            ConsumerDelegate<TNativeProperties, TMessage> next)
+        {
+            this.next = next;
+        }
+
+        public Task<ProcessResult> InvokeAsync(
+            ConsumerContext<TNativeProperties, TMessage> context,
+            RabbitProducerShould.ITestCaller testCaller,
+            CancellationToken cancellationToken)
+        {
+            testCaller.Call($"{nameof(GenericClientSpecificConventionalMiddleware<TNativeProperties, TMessage>)} with {typeof(TNativeProperties).Name}, {typeof(TMessage).Name}");
+            return next.Invoke(context, cancellationToken);
+        }
+    }
+    private class Processor : IProcessor<RabbitMessage>
+    {
+        private readonly RabbitProducerShould.ITestCaller testCaller;
+
+        public Processor(
+            RabbitProducerShould.ITestCaller testCaller)
+        {
+            this.testCaller = testCaller;
+        }
+
+        public Task<ProcessResult> Process(RabbitMessage message, CancellationToken cancellationToken)
+        {
+            testCaller.Call(message.Text);
+            return Task.FromResult(ProcessResult.Success);
+        }
+    }
+
+    private record RabbitMessage(string Text);
+}

--- a/src/RMQ.Client.Tests/RabbitFixture.cs
+++ b/src/RMQ.Client.Tests/RabbitFixture.cs
@@ -7,12 +7,12 @@ using RMQ.Client.DependencyInjection;
 
 namespace RMQ.Client.Tests;
 
-public class RabbitProducerFixture : IDisposable
+public class RabbitFixture : IDisposable
 {
     public IServiceCollection ServiceCollection { get; }
     private readonly DefaultServiceProviderFactory providerFactory;
 
-    public RabbitProducerFixture()
+    public RabbitFixture()
     {
         providerFactory = new DefaultServiceProviderFactory();
         ServiceCollection = providerFactory.CreateBuilder(new ServiceCollection());

--- a/src/RMQ.Client.Tests/RabbitProducerShould.cs
+++ b/src/RMQ.Client.Tests/RabbitProducerShould.cs
@@ -6,13 +6,13 @@ using RMQ.Client.Abstractions.Producing;
 
 namespace RMQ.Client.Tests;
 
-public class RabbitProducerShould : IClassFixture<RabbitProducerFixture>
+public class RabbitProducerShould : IClassFixture<RabbitFixture>
 {
-    private readonly RabbitProducerFixture fixture;
+    private readonly RabbitFixture fixture;
     private readonly Mock<ITestCaller> caller;
 
     public RabbitProducerShould(
-        RabbitProducerFixture fixture)
+        RabbitFixture fixture)
     {
         this.fixture = fixture;
         caller = new Mock<ITestCaller>();
@@ -21,10 +21,9 @@ public class RabbitProducerShould : IClassFixture<RabbitProducerFixture>
         fixture.ServiceCollection.AddScoped<ClientAgnosticInterfacedMiddleware>();
         fixture.ServiceCollection.AddScoped<ClientSpecificInterfacedMiddleware>();
         fixture.ServiceCollection.AddScoped<ClientSpecificWrongInterfacedMiddleware>();
-        fixture.ServiceCollection.AddScoped(typeof(GenericClientSpecificConventionalMiddleware<>));
     }
 
-    [Fact(Skip = "Integration tests are skipped for now")]
+    [Fact(Skip = "No integration tests yet")]
     public async Task PublishEncodedMessage()
     {
         var producerBuilder = fixture.GetProducerBuilder();

--- a/src/RMQ.Client/Defaults/DefaultBodyEncodingMiddleware.cs
+++ b/src/RMQ.Client/Defaults/DefaultBodyEncodingMiddleware.cs
@@ -1,10 +1,11 @@
 ﻿using System.Text.Json;
+using RabbitMQ.Client.Events;
 using RMQ.Client.Abstractions.Consuming;
 using RMQ.Client.Abstractions.Producing;
 
 namespace RMQ.Client.Defaults;
 
-public class DefaultBodyEncodingMiddleware : IProducerMiddleware, IConsumerMiddleware
+public class DefaultBodyEncodingMiddleware : IProducerMiddleware, IConsumerMiddleware<BasicDeliverEventArgs>
 {
     private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
 
@@ -18,11 +19,11 @@ public class DefaultBodyEncodingMiddleware : IProducerMiddleware, IConsumerMiddl
     }
 
     public Task<ProcessResult> InvokeAsync<TMessage>(
-        ConsumerContext<TMessage> context,
-        ConsumerDelegate<TMessage> next,
+        ConsumerContext<BasicDeliverEventArgs, TMessage> context,
+        ConsumerDelegate<BasicDeliverEventArgs, TMessage> next,
         CancellationToken cancellationToken)
     {
-        var message = JsonSerializer.Deserialize<TMessage>(context.NativeDeliverEvent.Body.Span, SerializerOptions);
+        var message = JsonSerializer.Deserialize<TMessage>(context.NativeProperties.Body.Span, SerializerOptions);
         context.Message = message;
         return next.Invoke(context, cancellationToken);
     }

--- a/src/RMQ.Client/MiddlewareCompiler.cs
+++ b/src/RMQ.Client/MiddlewareCompiler.cs
@@ -1,0 +1,87 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using RMQ.Client.Abstractions.Exceptions;
+
+namespace RMQ.Client;
+
+internal static class MiddlewareCompiler
+{
+    /// <summary>
+    /// Replace
+    /// <remarks>
+    /// public class Middleware
+    /// {
+    ///     public Task InvokeAsync(TContext context, IDependency dependency)
+    /// }
+    /// </remarks>
+    /// with
+    /// <remarks>
+    /// Task InvokeAsync(Middleware instance, TContext context, IServiceProvider provider)
+    /// {
+    ///     return instance.InvokeAsync(context, (IDependency) ProducerBuilder.GetService(provider, typeof(IDependency));
+    /// }
+    /// </remarks>
+    /// </summary>
+    public static Func<object, TContext, IServiceProvider, CancellationToken, TResult> Compile<TContext, TResult>(
+            MethodInfo methodInfo, IReadOnlyList<ParameterInfo> parameters) where TResult : Task
+    {
+        var contextGenericArguments = typeof(TContext).GetGenericArguments();
+
+        var consumerContextArg = Expression.Parameter(typeof(TContext), "context");
+        var providerArg = Expression.Parameter(typeof(IServiceProvider), "serviceProvider");
+        var cancellationTokenArg = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
+        var instanceArg = Expression.Parameter(typeof(object), "middleware");
+
+        var methodArguments = new Expression[parameters.Count];
+        methodArguments[0] = consumerContextArg;
+        methodArguments[parameters.Count - 1] = cancellationTokenArg;
+        for (var i = 1; i < parameters.Count - 1; i++)
+        {
+            var parameterType = parameters[i].ParameterType;
+            if (parameterType.IsByRef)
+            {
+                throw ConsumerBuilderMiddlewareConventionException.NotSupported();
+            }
+
+            var parameterTypeExpression = new Expression[]
+            {
+                providerArg,
+                Expression.Constant(parameterType, typeof(Type))
+            };
+
+            var getServiceCall = Expression.Call(GetServiceInfo, parameterTypeExpression);
+            methodArguments[i] = Expression.Convert(getServiceCall, parameterType);
+        }
+
+        Expression middlewareInstanceArg = instanceArg;
+        if (methodInfo.DeclaringType is not null && methodInfo.DeclaringType != typeof(object))
+        {
+            var declaringType = methodInfo.DeclaringType.IsGenericTypeDefinition
+                ? methodInfo.DeclaringType.GetGenericTypeDefinition().MakeGenericType(contextGenericArguments)
+                : methodInfo.DeclaringType;
+            middlewareInstanceArg = Expression.Convert(middlewareInstanceArg, declaringType);
+        }
+
+        var body = methodInfo switch
+        {
+            {IsGenericMethod: true} =>
+                Expression.Call(middlewareInstanceArg, methodInfo.Name, contextGenericArguments, methodArguments),
+            {ContainsGenericParameters: true} =>
+                Expression.Call(middlewareInstanceArg, methodInfo.Name, Type.EmptyTypes, methodArguments),
+            _ =>
+                Expression.Call(middlewareInstanceArg, methodInfo, methodArguments)
+        };
+        var lambda =
+            Expression.Lambda<Func<object, TContext, IServiceProvider, CancellationToken, TResult>>(
+                body, instanceArg, consumerContextArg, providerArg, cancellationTokenArg);
+
+        return lambda.Compile();
+    }
+
+    private static object GetService(IServiceProvider serviceProvider, Type type) =>
+        serviceProvider.GetRequiredService(type);
+
+    private static readonly MethodInfo GetServiceInfo = typeof(MiddlewareCompiler)
+        .GetMethod(nameof(GetService), BindingFlags.NonPublic | BindingFlags.Static)!;
+}


### PR DESCRIPTION
In order to support multiple RabbitMQ clients, the Consumer middlewares should be able to be client-agnostic.