### PR TITLE
[Jamq.Rabbit] Consumer context properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,19 +330,21 @@ In other cases you still don't care about the message type, but it is essential 
 ```csharp
 public class ConsumerOpenTelemetryMiddleware
 {
-    private readonly ConsumerDelegate<BasicDeliverEventArgs> next;
+    private readonly ConsumerDelegate<RabbitConsumerProperties> next;
 
-    public ConsumerOpenTelemetryMiddleware(ConsumerDelegate<BasicDeliverEventArgs> next)
+    public ConsumerOpenTelemetryMiddleware(ConsumerDelegate<RabbitConsumerProperties> next)
     {
         this.next = next;
     }
 
     public async Task<ProcessResult> InvokeNext(
-        ConsumerContext<BasicDeliverEventArgs> context,
+        ConsumerContext<RabbitConsumerProperties> context,
         CancellationToken token)
     {
         var parentContext = Propagator.Extract(
-            default, context.NativeProperties.BasicProperties, ExtractTraceContext);
+            default,
+            context.NativeProperties.BasicDeliverEventArgs.BasicProperties,
+            ExtractTraceContext);
         Baggage.Current = parentContext.Baggage;
 
         var activityName = $"{context.NativeProperties.ConsumerTag} incoming message";
@@ -354,7 +356,7 @@ public class ConsumerOpenTelemetryMiddleware
     }
     
     private static IEnumerable<string> ExtractTraceContext(IBasicProperties properties, string key) =>
-        properties.Headers.TryGetValue(key, out var header)
+        properties.Headers?.TryGetValue(key, out var header) is true
             ? new[] { Encoding.UTF8.GetString(header as byte[]) }
             : Enumerable.Empty<string>();
 }
@@ -367,14 +369,14 @@ A lot of stuff going on here, and the source code is based on the public example
 Another common scenario - is middleware that is aware of the client, but needs to be generic of the message type. Usually you will need that to implement your own decoding middleware:
 
 ```csharp
-public class NewtonsoftJsonDecodingMiddleware<TMessage> : IConsumerMiddleware<BasicDeliverEventArgs, TMessage>
+public class NewtonsoftJsonDecodingMiddleware<TMessage> : IConsumerMiddleware<RabbitConsumerProperties, TMessage>
 {
     public Task<ProcessResult> InvokeAsync(
-        ConsumerContext<BasicDeliverEventArgs, TMessage> context,
-        ConsumerDelegate<BasicDeliverEventArgs, TMessage> next,
+        ConsumerContext<RabbitConsumerProperties, TMessage> context,
+        ConsumerDelegate<RabbitConsumerProperties, TMessage> next,
         CancellationToken token)
     {
-        var utf8Body = Encoding.UTF8.GetString(context.NativeProperties.Body.ToArray());
+        var utf8Body = Encoding.UTF8.GetString(context.NativeProperties.BasicDeliverEventArgs.Body.ToArray());
         var message = JsonConvert.DeserializeObject<TMessage>(utf8Body);
         context.Message = message;
         return next.Invoke(context, token);
@@ -422,7 +424,7 @@ public ConsumerService : BackgroundService
     public ConsumerService(IConsumerBuilder builder) { this.builder = builder; }
 
     public override async ExecuteAsync(CancellationToken token) => builder
-        .With<BasicDeliverEventArgs, string>(next => (context, ct) => {
+        .With<RabbitConsumerProperties, string>(next => (context, ct) => {
             var logger = context.ServiceProvider.GetRequiredService<ILogger<ConsumerService>>();
             logger.LogInformation("Here goes the string message: {Message}", context.Message);
             return next.Invoke(context, ct);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Authors>quilin</Authors>
         <Owners>quilin</Owners>
-        <PackageTags>RabbitMQ, Client</PackageTags>
+        <PackageTags>RabbitMQ, Kafka, Client</PackageTags>
         <RepositoryUrl>https://github.com/quilin/Jamq.Client</RepositoryUrl>
         <PackageProjectUrl>https://github.com/quilin/Jamq.Client</PackageProjectUrl>
     </PropertyGroup>

--- a/src/Jamq.Client.Rabbit.DependencyInjection/JamqClientConfigurationExtensions.cs
+++ b/src/Jamq.Client.Rabbit.DependencyInjection/JamqClientConfigurationExtensions.cs
@@ -41,7 +41,7 @@ public static class JamqClientConfigurationExtensions
                 ["platform"] = ".NET",
                 ["platform-version"] = Environment.Version.ToString(),
                 ["product"] = "Jamq.Client",
-                ["version"] = "0.3.1"
+                ["version"] = "0.5.1"
             }
         };
 }

--- a/src/Jamq.Client.Rabbit/Consuming/ConsumerBuilderExtensions.cs
+++ b/src/Jamq.Client.Rabbit/Consuming/ConsumerBuilderExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using RabbitMQ.Client.Events;
 using Jamq.Client.Abstractions.Consuming;
 using Jamq.Client.Rabbit.Connection;
 
@@ -21,7 +20,7 @@ public static class ConsumerBuilderExtensions
         RabbitConsumerParameters parameters)
         where TProcessor : IProcessor<string, TMessage>
     {
-        var components = builder.GetMiddlewares<string, TMessage, BasicDeliverEventArgs>();
+        var components = builder.GetMiddlewares<string, TMessage, RabbitConsumerProperties>();
 
         var serviceProvider = builder.GetServiceProvider();
         var channelPool = serviceProvider.GetRequiredService<IConsumerChannelPool>();

--- a/src/Jamq.Client.Rabbit/Consuming/RabbitConsumerProperties.cs
+++ b/src/Jamq.Client.Rabbit/Consuming/RabbitConsumerProperties.cs
@@ -1,0 +1,18 @@
+using RabbitMQ.Client.Events;
+
+namespace Jamq.Client.Rabbit.Consuming;
+
+public class RabbitConsumerProperties
+{
+    internal RabbitConsumerProperties(
+        BasicDeliverEventArgs basicDeliverEventArgs,
+        RabbitConsumerParameters parameters)
+    {
+        BasicDeliverEventArgs = basicDeliverEventArgs;
+        Parameters = parameters;
+    }
+
+    public BasicDeliverEventArgs BasicDeliverEventArgs { get; }
+
+    public RabbitConsumerParameters Parameters { get; }
+}

--- a/src/Jamq.Client.Rabbit/Defaults/DefaultRabbitBodyDecodingMiddleware.cs
+++ b/src/Jamq.Client.Rabbit/Defaults/DefaultRabbitBodyDecodingMiddleware.cs
@@ -1,18 +1,18 @@
 ﻿using System.Text.Json;
-using RabbitMQ.Client.Events;
 using Jamq.Client.Abstractions.Consuming;
+using Jamq.Client.Rabbit.Consuming;
 
 namespace Jamq.Client.Rabbit.Defaults;
 
-public class DefaultRabbitBodyDecodingMiddleware<TMessage> : IConsumerMiddleware<string, TMessage, BasicDeliverEventArgs>
+public class DefaultRabbitBodyDecodingMiddleware<TMessage> : IConsumerMiddleware<string, TMessage, RabbitConsumerProperties>
 {
     public Task<ProcessResult> InvokeAsync(
-        ConsumerContext<string, TMessage, BasicDeliverEventArgs> context,
-        ConsumerDelegate<string, TMessage, BasicDeliverEventArgs> next,
+        ConsumerContext<string, TMessage, RabbitConsumerProperties> context,
+        ConsumerDelegate<string, TMessage, RabbitConsumerProperties> next,
         CancellationToken cancellationToken)
     {
         var message = JsonSerializer.Deserialize<TMessage>(
-            context.NativeProperties.Body.Span, DefaultBodyEncodingSettings.SerializerOptions);
+            context.NativeProperties.BasicDeliverEventArgs.Body.Span, DefaultBodyEncodingSettings.SerializerOptions);
         context.Message = message;
 
         return next.Invoke(context, cancellationToken);

--- a/src/Jamq.Client.Rabbit/Producing/RabbitProducer.cs
+++ b/src/Jamq.Client.Rabbit/Producing/RabbitProducer.cs
@@ -62,7 +62,7 @@ internal class RabbitProducer<TMessage> : IProducer<string, TMessage>
         await using var scope = serviceProvider.CreateAsyncScope();
 
         var basicProperties = channelAccessor.Value.Channel.CreateBasicProperties();
-        var nativeProperties = new RabbitProducerProperties(basicProperties);
+        var nativeProperties = new RabbitProducerProperties(basicProperties, parameters);
         var context = new ProducerContext<string, TMessage, RabbitProducerProperties>(
             scope.ServiceProvider, nativeProperties, routingKey, message);
         await pipeline.Invoke(context, cancellationToken);

--- a/src/Jamq.Client.Rabbit/Producing/RabbitProducerProperties.cs
+++ b/src/Jamq.Client.Rabbit/Producing/RabbitProducerProperties.cs
@@ -5,12 +5,16 @@ namespace Jamq.Client.Rabbit.Producing;
 public class RabbitProducerProperties
 {
     internal RabbitProducerProperties(
-        IBasicProperties basicProperties)
+        IBasicProperties basicProperties,
+        RabbitProducerParameters parameters)
     {
         BasicProperties = basicProperties;
+        Parameters = parameters;
     }
 
     public IBasicProperties BasicProperties { get; }
+
+    public RabbitProducerParameters Parameters { get; }
 
     public byte[]? Body { get; set; }
 }


### PR DESCRIPTION
Native RabbitMqClient consumed message properties are enveloped to RabbitConsumerProperties and enriched with consumer parameters to enable proper diagnostics middlewares etc.