### PR TITLE
Customizations for the declared queues and exchanges

### DIFF
--- a/src/Jamq.Client.Rabbit/Consuming/RabbitConsumerParameters.cs
+++ b/src/Jamq.Client.Rabbit/Consuming/RabbitConsumerParameters.cs
@@ -58,6 +58,10 @@ public class RabbitConsumerParameters
     /// </summary>
     public TimeSpan MaxProcessingAnticipation { get; init; } = TimeSpan.FromSeconds(30);
 
+    public IDictionary<string, object>? AdditionalQueueArguments { get; init; }
+
+    public IDictionary<string, object>? AdditionalExchangeArguments { get; init; }
+
     public RabbitConsumerParameters(
         string consumerTag,
         string queueName,


### PR DESCRIPTION
Ability to define custom arguments for the created exchanges and queues

Avoiding creating the Dead Letter Exchange automatically, it is out of scope of the consumer definition